### PR TITLE
Adding tenant param for cases where domain and tenant differs

### DIFF
--- a/modules/enum/o365_enum_onedrive.py
+++ b/modules/enum/o365_enum_onedrive.py
@@ -101,9 +101,10 @@ class OmniModule(object):
 
             # Collect the pieces to build the One Drive URL
             domain_array = (self.args.domain.split('.'))
+            tenant_array = (self.args.tenant.split('.')) if self.args.tenant else []
 
             domain = domain_array[0]        # Collect the domain
-            tenant = domain                 # Use domain as tenant
+            tenant = tenant_array[0] if tenant_array else domain  # if tenant param exists use it instead of domain
             tld    = domain_array[-1]       # Grab the TLD
             user   = user.replace(".","_")  # Replace any `.` with `_` for use in the URL
 

--- a/omnispray.py
+++ b/omnispray.py
@@ -49,6 +49,14 @@ if __name__ == "__main__":
         help="Target domain for enumeration/spraying."
     )
 
+    # Tenant name to be used in case it differs from users domain
+    parser.add_argument(
+        "-tenant",
+        "--tenant",
+        type=str,
+        help="Target tenant name in case it differs with domain for enumeration/spraying."
+    )
+
     # Module type
     parser.add_argument(
         "-t",


### PR DESCRIPTION
Sometimes we want to enumerate users in environments where domain and tenant are not equal.