### PR TITLE
Remove Email Format Check

### DIFF
--- a/modules/spray/o365_spray_adfs.py
+++ b/modules/spray/o365_spray_adfs.py
@@ -106,11 +106,6 @@ class OmniModule(object):
             if self.args.domain:
                 user = build_email(user, self.args.domain)
 
-            elif not check_email(user):
-                logging.error(f"Invalid user: {user}")
-                self.users.remove(user)
-                return
-
             # Build user:password var for reuse with spacing
             creds = f"{user}:{password}"
 


### PR DESCRIPTION
The ADFS Module requires that the username be in email format.  You can also login using domain\User.  