### PR TITLE
Fix typo in MSOL spray module

### DIFF
--- a/modules/spray/o365_spray_msol.py
+++ b/modules/spray/o365_spray_msol.py
@@ -172,7 +172,7 @@ class OmniModule(object):
                         err_msg = AADSTS_CODES[code][1]
                         msg     = f" [{err}: {err_msg}]"
                         logging.info(f"{text_colors.red}[ - ]{text_colors.reset} {user}:{password}{msg}")
-                        self.userlist.remove(user)
+                        self.users.remove(user)
                         break
 
                 # Only executed if the inner loop did NOT break

--- a/modules/spray/o365_spray_msol.py
+++ b/modules/spray/o365_spray_msol.py
@@ -92,7 +92,7 @@ class OmniModule(object):
                 https://gist.github.com/byt3bl33d3r/19a48fff8fdc34cc1dd1f1d2807e1b7f '''
 
             # Check if we hit our locked account limit, and stop
-            if self.locked_count >= self.lockout_limit:
+            if self.locked_count >= self.locked_limit:
                 return
 
             # Write the tested user in its original format with the password


### PR DESCRIPTION
Currently the Oauth2 based MSOL spray module doesn't spray any accounts due to an error in the name of a variable. The OmniModule class declares a `self.locked_limit` instance variable but the `_execute` function is trying to access a `self.lockout_limit` member, which doesn't exist and causes the module to error out and not spray any accounts.

Updated the variable name in the `_execute()` function to access the correct instance variable. 